### PR TITLE
add error checking to jq and curl subshell invocation

### DIFF
--- a/revbump_blank.sh
+++ b/revbump_blank.sh
@@ -20,71 +20,118 @@ pkg_sub_modules=(
 
 
 
+function err_msg() {
+    echo -en "error: $*\n" 1>&2
+}
+
 #test for jq
 if ! which jq >/dev/null 2>&1 ; then
-    echo "this script requires jq https://stedolan.github.io/jq/ (app-misc/jq on Gentoo)"
+    err_msg "this script requires jq https://stedolan.github.io/jq/\n\t\t( app-misc/jq on Gentoo )"
     exit 1
 fi
 #test for curl
 if ! which curl >/dev/null 2>&1 ; then
-    echo "this script requires curl https://curl.haxx.se/ (net-misc/curl on Gentoo)"
+    err_msg "this script requires curl https://curl.haxx.se/\n\t\t( net-misc/curl on Gentoo )"
     exit 1
 fi
 #test for git
 if ! which git >/dev/null 2>&1 ; then
-    echo "this script requires git https://www.git-scm.com/ (dev-vcs/git on Gentoo)"
+    err_msg "this script requires git https://www.git-scm.com/\n\t\t( dev-vcs/git on Gentoo )"
     exit 1
 fi
 
-jq_cmd="jq --raw-output"
+## jq function to handle stdin, arg[n], and suppress stderr
+function jq_cmd() {
+    local err_code jq_args
+    #jq with --exit-status will return non-zero on not found / null
+    jq_args="--exit-status --raw-output"
+    if [ ! -p /dev/stdin ] ; then
+        err_msg "jq_cmd not fed with stdin"
+        return 1
+    elif [ -z "$1" ] ; then
+        err_msg "jq_cmd not provided with filter"
+        return 1
+    fi
+    #silence jq stderr output
+    # jq filter not found has no output, and returns non zero
+    # jq input not json outputs 'jq: parse error: <something> at line x, column y', and returns non zero
+    #shellcheck disable=SC2086 #actually want word splitting
+    cat -|jq ${jq_args} "$@" 2>/dev/null
+    err_code="$?"
+    if [ ${err_code} -gt 0 ] ; then
+        err_msg "jq failed to parse"
+        return 1
+    fi
+}
+
 ## curl function to keep quoting sane
 function curl_cmd() {
-    curl --header 'Accept: application/vnd.github+json' --silent "$@"
+    local curl_out err_code
+    #curl --fail will give us an exit code of 22 for 404s
+    curl_out=$(curl --fail --header 'Accept: application/vnd.github+json' --silent "$@")
+    err_code="$?"
+    if [ ${err_code} -gt 0 ] ; then
+        err_msg "curl response \"${err_code}\" for URI \"$*\""
+        #jq will fail to parse 'FAIL'
+        echo "FAIL"
+        return 1
+    else
+        echo "${curl_out}"
+    fi
 }
 
 ## collect our package variables
 function vars_github_api() {
     local tag_sha commit_sha
     #grab latest release tag (version)
-    pkg_ver="$(curl_cmd "${pkg_git_base}/releases/latest" |${jq_cmd} '.tag_name')"
+    pkg_ver="$(curl_cmd "${pkg_git_base}/releases/latest"|jq_cmd '.tag_name')" || return 1
     #get version major.minor
     pkg_maj_min="$(echo "${pkg_ver}"|grep -Eo '[0-9]+\.[0-9]+')"
     #using release tag grab tag sha
-    tag_sha="$(curl_cmd "${pkg_git_base}/git/ref/tags/${pkg_ver}" |${jq_cmd} '.object.sha')"
+    tag_sha="$(curl_cmd "${pkg_git_base}/git/ref/tags/${pkg_ver}" |jq_cmd '.object.sha')" || return 1
     #using tag sha grab commit sha
-    commit_sha="$(curl_cmd "${pkg_git_base}/git/tags/${tag_sha}" |${jq_cmd} '.object.sha')"
+    commit_sha="$(curl_cmd "${pkg_git_base}/git/tags/${tag_sha}" |jq_cmd '.object.sha')" || return 1
 
     #iterate over git sub-modules and get mod info using commit sha
-    local cur_sub_module sub_mod_info sub_mod_sha
+    local cur_sub_module sub_mod_info sub_mod_sha sub_mod_fail
     for cur_sub_module in "${pkg_sub_modules[@]}" ; do
         #pulling into sub_mod_info to reduce curl invocations
         #  ${var#*:} remove everything infront of first : (including the first :)
-        sub_mod_info="$(curl_cmd "${cur_sub_module#*:}?ref=${commit_sha}")"
+        sub_mod_info="$(curl_cmd "${cur_sub_module#*:}?ref=${commit_sha}")" || {
+            #space added to end to ensure readability
+            sub_mod_fail+="${cur_sub_module%%:*} "
+            continue
+        }
         #test that dir is actually a git sub-module
-        if [ "$(echo "${sub_mod_info}"|${jq_cmd} '.type')" != "submodule" ]; then
+        if [ "$(echo "${sub_mod_info}"|jq_cmd '.type')" != "submodule" ]; then
             #upstream changed layout or dependancies
             #  ${var%%:*} remove everything after first : (including the first :)
-            echo "upstream changes to ${cur_sub_module%%:*} submodule, bailing out"
-            exit 1
+            err_msg "upstream changes to ${cur_sub_module%%:*} submodule, bailing out"
+            return 1
         else
             #extract sha from saved json
-            sub_mod_sha=$(echo "${sub_mod_info}"|${jq_cmd} '.sha')
+            sub_mod_sha=$(echo "${sub_mod_info}"|jq_cmd '.sha')
 	        if [ "${sub_mod_sha}" = "" ] || [ "${sub_mod_sha}" = "null" ]; then
                 #issue with github api?
-                echo "could not get sha for ${cur_sub_module%%:*} submodule, api issue?"
-                exit 1
+                err_msg "could not get sha for ${cur_sub_module%%:*} submodule, api issue?"
+                return 1
             fi
         fi
         #indirect parameter expansion, setting the eventual ebuild variable to it's sha value
         export "${cur_sub_module%%:*}"="${sub_mod_sha}"
     done
+    if [ -n "${sub_mod_fail[*]}" ] ; then
+        err_msg "failed to get api info for submodules ${sub_mod_fail[*]}"
+        return 1
+    fi
 }
 
 ## replace variable strings in the ebuild
 function update_ebuild() {
     if [ -e "${ebuild}" ] ; then
-        echo "no changes needed $pkg $pkg_ver ebuild exists"
-        exit
+        err_msg "no changes needed $pkg $pkg_ver ebuild exists"
+        #return 1 to short circuit running git [add, commit, push]
+        return 1
     fi
 
     cp -v "${from}" "${ebuild}"
@@ -106,23 +153,23 @@ function update_ebuild() {
 
 ## update the overlay repo
 function push_to_overlay() {
-    cd "${repo}" || { echo "could not change to ${repo} dir" ; return 1 ; }
+    cd "${repo}" || { err_msg "could not change to ${repo} dir" ; return 1 ; }
     git pull
 
-    update_ebuild
+    update_ebuild || return
 
     git add .
     git commit -asm "${pkg} auto-verbump"
     git push
 }
 
-vars_github_api
+vars_github_api || { err_msg "could not get package variables" ; exit 1 ; }
 
 ebuild="${pkg}-${pkg_ver}.ebuild"
 #if there is a live build for this major.minor then base upon that
 # this caters for situations where upstream has different dependencies
 # between stable and dev branches
-if [ -e "${pkg}-${pkg_maj_min}.9999.ebuild" ]; then
+if [ -e "${repo}/${pkg}-${pkg_maj_min}.9999.ebuild" ]; then
     from="${pkg}-${pkg_maj_min}.9999.ebuild"
 else
     from="${pkg}-9999.ebuild"

--- a/zoneminder.sh
+++ b/zoneminder.sh
@@ -17,71 +17,118 @@ MY_RTSP_V:"${pkg_git_base}/contents/dep/RtspServer"
 
 
 
+function err_msg() {
+    echo -en "error: $*\n" 1>&2
+}
+
 #test for jq
 if ! which jq >/dev/null 2>&1 ; then
-    echo "this script requires jq https://stedolan.github.io/jq/ (app-misc/jq on Gentoo)"
+    err_msg "this script requires jq https://stedolan.github.io/jq/\n\t\t( app-misc/jq on Gentoo )"
     exit 1
 fi
 #test for curl
 if ! which curl >/dev/null 2>&1 ; then
-    echo "this script requires curl https://curl.haxx.se/ (net-misc/curl on Gentoo)"
+    err_msg "this script requires curl https://curl.haxx.se/\n\t\t( net-misc/curl on Gentoo )"
     exit 1
 fi
 #test for git
 if ! which git >/dev/null 2>&1 ; then
-    echo "this script requires git https://www.git-scm.com/ (dev-vcs/git on Gentoo)"
+    err_msg "this script requires git https://www.git-scm.com/\n\t\t( dev-vcs/git on Gentoo )"
     exit 1
 fi
 
-jq_cmd="jq --raw-output"
+## jq function to handle stdin, arg[n], and suppress stderr
+function jq_cmd() {
+    local err_code jq_args
+    #jq with --exit-status will return non-zero on not found / null
+    jq_args="--exit-status --raw-output"
+    if [ ! -p /dev/stdin ] ; then
+        err_msg "jq_cmd not fed with stdin"
+        return 1
+    elif [ -z "$1" ] ; then
+        err_msg "jq_cmd not provided with filter"
+        return 1
+    fi
+    #silence jq stderr output
+    # jq filter not found has no output, and returns non zero
+    # jq input not json outputs 'jq: parse error: <something> at line x, column y', and returns non zero
+    #shellcheck disable=SC2086 #actually want word splitting
+    cat -|jq ${jq_args} "$@" 2>/dev/null
+    err_code="$?"
+    if [ ${err_code} -gt 0 ] ; then
+        err_msg "jq failed to parse"
+        return 1
+    fi
+}
+
 ## curl function to keep quoting sane
 function curl_cmd() {
-    curl --header 'Accept: application/vnd.github+json' --silent "$@"
+    local curl_out err_code
+    #curl --fail will give us an exit code of 22 for 404s
+    curl_out=$(curl --fail --header 'Accept: application/vnd.github+json' --silent "$@")
+    err_code="$?"
+    if [ ${err_code} -gt 0 ] ; then
+        err_msg "curl response \"${err_code}\" for URI \"$*\""
+        #jq will fail to parse 'FAIL'
+        echo "FAIL"
+        return 1
+    else
+        echo "${curl_out}"
+    fi
 }
 
 ## collect our package variables
 function vars_github_api() {
     local tag_sha commit_sha
     #grab latest release tag (version)
-    pkg_ver="$(curl_cmd "${pkg_git_base}/releases/latest" |${jq_cmd} '.tag_name')"
+    pkg_ver="$(curl_cmd "${pkg_git_base}/releases/latest"|jq_cmd '.tag_name')" || return 1
     #get version major.minor
     pkg_maj_min="$(echo "${pkg_ver}"|grep -Eo '[0-9]+\.[0-9]+')"
     #using release tag grab tag sha
-    tag_sha="$(curl_cmd "${pkg_git_base}/git/ref/tags/${pkg_ver}" |${jq_cmd} '.object.sha')"
+    tag_sha="$(curl_cmd "${pkg_git_base}/git/ref/tags/${pkg_ver}" |jq_cmd '.object.sha')" || return 1
     #using tag sha grab commit sha
-    commit_sha="$(curl_cmd "${pkg_git_base}/git/tags/${tag_sha}" |${jq_cmd} '.object.sha')"
+    commit_sha="$(curl_cmd "${pkg_git_base}/git/tags/${tag_sha}" |jq_cmd '.object.sha')" || return 1
 
     #iterate over git sub-modules and get mod info using commit sha
-    local cur_sub_module sub_mod_info sub_mod_sha
+    local cur_sub_module sub_mod_info sub_mod_sha sub_mod_fail
     for cur_sub_module in "${pkg_sub_modules[@]}" ; do
         #pulling into sub_mod_info to reduce curl invocations
         #  ${var#*:} remove everything infront of first : (including the first :)
-        sub_mod_info="$(curl_cmd "${cur_sub_module#*:}?ref=${commit_sha}")"
+        sub_mod_info="$(curl_cmd "${cur_sub_module#*:}?ref=${commit_sha}")" || {
+            #space added to end to ensure readability
+            sub_mod_fail+="${cur_sub_module%%:*} "
+            continue
+        }
         #test that dir is actually a git sub-module
-        if [ "$(echo "${sub_mod_info}"|${jq_cmd} '.type')" != "submodule" ]; then
+        if [ "$(echo "${sub_mod_info}"|jq_cmd '.type')" != "submodule" ]; then
             #upstream changed layout or dependancies
             #  ${var%%:*} remove everything after first : (including the first :)
-            echo "upstream changes to ${cur_sub_module%%:*} submodule, bailing out"
-            exit 1
+            err_msg "upstream changes to ${cur_sub_module%%:*} submodule, bailing out"
+            return 1
         else
             #extract sha from saved json
-            sub_mod_sha=$(echo "${sub_mod_info}"|${jq_cmd} '.sha')
+            sub_mod_sha=$(echo "${sub_mod_info}"|jq_cmd '.sha')
 	        if [ "${sub_mod_sha}" = "" ] || [ "${sub_mod_sha}" = "null" ]; then
                 #issue with github api?
-                echo "could not get sha for ${cur_sub_module%%:*} submodule, api issue?"
-                exit 1
+                err_msg "could not get sha for ${cur_sub_module%%:*} submodule, api issue?"
+                return 1
             fi
         fi
         #indirect parameter expansion, setting the eventual ebuild variable to it's sha value
         export "${cur_sub_module%%:*}"="${sub_mod_sha}"
     done
+    if [ -n "${sub_mod_fail[*]}" ] ; then
+        err_msg "failed to get api info for submodules ${sub_mod_fail[*]}"
+        return 1
+    fi
 }
 
 ## replace variable strings in the ebuild
 function update_ebuild() {
     if [ -e "${ebuild}" ] ; then
-        echo "no changes needed $pkg $pkg_ver ebuild exists"
-        exit
+        err_msg "no changes needed $pkg $pkg_ver ebuild exists"
+        #return 1 to short circuit running git [add, commit, push]
+        return 1
     fi
 
     cp -v "${from}" "${ebuild}"
@@ -103,17 +150,17 @@ function update_ebuild() {
 
 ## update the overlay repo
 function push_to_overlay() {
-    cd "${repo}" || { echo "could not change to ${repo} dir" ; return 1 ; }
+    cd "${repo}" || { err_msg "could not change to ${repo} dir" ; return 1 ; }
     git pull
 
-    update_ebuild
+    update_ebuild || return
 
     git add .
     git commit -asm "${pkg} auto-verbump"
     git push
 }
 
-vars_github_api
+vars_github_api || { err_msg "could not get package variables" ; exit 1 ; }
 
 ebuild="${repo}/${pkg}-${pkg_ver}.ebuild"
 #if there is a live build for this major.minor then base upon that


### PR DESCRIPTION
* add err_msg function to divert output error stings to stderr
* add --fail to curl invocation to force it to exit non-zero on 404
* wrap jq in a function and add --exit-status to force non-zero exit on:
   parse failure || filter not found || filter result is null
* fix exit -> return in functions
* fix test for existing live ebuild (M.m.9999.ebuild) in revbump_blank.sh
   existing fix (full path via ${repo}) in zoneminder.sh left unchanged